### PR TITLE
Filenames and corresponding references shortened for DefinitionInfoCollector code and header files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(cpp2c SHARED
   AlignmentMatchers.cc
   Cpp2CAction.cc
   Cpp2CASTConsumer.cc
-  DefinitionInfoCollector.cc
+  DefnInfoCollector.cc
   DeclStmtTypeLoc.cc
   DeclCollectorMatchHandler.cc
   ExpansionMatchHandler.cc

--- a/src/Cpp2CASTConsumer.cc
+++ b/src/Cpp2CASTConsumer.cc
@@ -317,11 +317,11 @@ Cpp2CASTConsumer::Cpp2CASTConsumer(clang::CompilerInstance &CI) {
 
         MF = new cpp2c::MacroForest(PP, Ctx);
         IC = new cpp2c::IncludeCollector();
-        DC = new cpp2c::DefinitionInfoCollector(Ctx);
+        DC = new cpp2c::DefnInfoCollector(Ctx);
 
         PP.addPPCallbacks(std::unique_ptr<cpp2c::MacroForest>(MF));
         PP.addPPCallbacks(std::unique_ptr<cpp2c::IncludeCollector>(IC));
-        PP.addPPCallbacks(std::unique_ptr<cpp2c::DefinitionInfoCollector>(DC));
+        PP.addPPCallbacks(std::unique_ptr<cpp2c::DefnInfoCollector>(DC));
 }
 
 void Cpp2CASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {

--- a/src/Cpp2CASTConsumer.hh
+++ b/src/Cpp2CASTConsumer.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "DefinitionInfoCollector.hh"
+#include "DefnInfoCollector.hh"
 #include "IncludeCollector.hh"
 #include "MacroForest.hh"
 
@@ -12,7 +12,7 @@ class Cpp2CASTConsumer : public clang::ASTConsumer {
     private:
         cpp2c::MacroForest *MF;
         cpp2c::IncludeCollector *IC;
-        cpp2c::DefinitionInfoCollector *DC;
+        cpp2c::DefnInfoCollector *DC;
 
     public:
         Cpp2CASTConsumer(clang::CompilerInstance &CI);

--- a/src/DefnInfoCollector.cc
+++ b/src/DefnInfoCollector.cc
@@ -1,40 +1,40 @@
-#include "DefinitionInfoCollector.hh"
+#include "DefnInfoCollector.hh"
 
 namespace cpp2c {
 
-DefinitionInfoCollector::DefinitionInfoCollector(clang::ASTContext &Ctx)
+DefnInfoCollector::DefnInfoCollector(clang::ASTContext &Ctx)
         : SM(Ctx.getSourceManager())
         , LO(Ctx.getLangOpts()) {
 }
 
-void DefinitionInfoCollector::MacroDefined(const clang::Token &MacroNameTok,
+void DefnInfoCollector::MacroDefined(const clang::Token &MacroNameTok,
                                            const clang::MacroDirective *MD) {
         std::string Name = clang::Lexer::getSpelling(MacroNameTok, SM, LO);
         MacroNamesDefinitions.push_back({ Name, MD });
 }
 
-void DefinitionInfoCollector::MacroUndefined(
+void DefnInfoCollector::MacroUndefined(
         const clang::Token &MacroNameTok, const clang::MacroDefinition &MD,
         const clang::MacroDirective *Undef) {
         auto Name = clang::Lexer::getSpelling(MacroNameTok, SM, LO);
         InspectedMacroNames.insert(Name);
 }
 
-void DefinitionInfoCollector::Defined(const clang::Token &MacroNameTok,
+void DefnInfoCollector::Defined(const clang::Token &MacroNameTok,
                                       const clang::MacroDefinition &MD,
                                       clang::SourceRange Range) {
         auto Name = clang::Lexer::getSpelling(MacroNameTok, SM, LO);
         InspectedMacroNames.insert(Name);
 }
 
-void DefinitionInfoCollector::Ifdef(clang::SourceLocation Loc,
+void DefnInfoCollector::Ifdef(clang::SourceLocation Loc,
                                     const clang::Token &MacroNameTok,
                                     const clang::MacroDefinition &MD) {
         auto Name = clang::Lexer::getSpelling(MacroNameTok, SM, LO);
         InspectedMacroNames.insert(Name);
 }
 
-void DefinitionInfoCollector::Ifndef(clang::SourceLocation Loc,
+void DefnInfoCollector::Ifndef(clang::SourceLocation Loc,
                                      const clang::Token &MacroNameTok,
                                      const clang::MacroDefinition &MD) {
         auto Name = clang::Lexer::getSpelling(MacroNameTok, SM, LO);

--- a/src/DefnInfoCollector.hh
+++ b/src/DefnInfoCollector.hh
@@ -13,7 +13,7 @@
 #include <vector>
 
 namespace cpp2c {
-class DefinitionInfoCollector : public clang::PPCallbacks {
+class DefnInfoCollector : public clang::PPCallbacks {
     private:
         clang::SourceManager &SM;
         const clang::LangOptions &LO;
@@ -23,7 +23,7 @@ class DefinitionInfoCollector : public clang::PPCallbacks {
                 MacroNamesDefinitions;
         std::set<std::string> InspectedMacroNames;
 
-        DefinitionInfoCollector(clang::ASTContext &Ctx);
+        DefnInfoCollector(clang::ASTContext &Ctx);
 
         void MacroDefined(const clang::Token &MacroNameTok,
                           const clang::MacroDirective *MD) override;


### PR DESCRIPTION
Filenames changed and corresponding references changed:

![image](https://github.com/PappasBrent/maki/assets/3409169/a799302a-b93b-40e7-84ab-0a3e0ec858e6)

maki/src/CMakeLists.txt, Line 32 DefinitionInfoCollector.cc  to  DefnInfoCollector.cc maki/src/DefinitionInfoCollector.cc  to  maki/src/DefnInfoCollector.cc
     Line 1 #include "DefinitionInfoCollector.hh"  to  #include "DefnInfoCollector.hh"
     Line 5 DefinitionInfoCollector::DefinitionInfoCollector  to  DefnInfoCollector::DefnInfoCollector
     Line 10, 16, 23, 30, 37 void functions changed from DefinitionInfoCollector  to  DefnInfoCollector
maki/src/DefinitionInfoCollector.hh  to  maki/src/DefnInfoCollector.hh,
     and Line 16 class name DefinitionInfoCollector  to  DefnInfoCollector
     and Line 26 DefinitionInfoCollector  to DefnInfoCollector
maki/src/Cpp2CASTConsumer.hh
     Line 3 #include "DefinitionInfoCollector.hh"  to  #include "DefnInfoCollector.hh"
     Line 15 cpp2c::DefinitionInfoCollector *DC;  to  cpp2c::DefnInfoCollector *DC;
maki/src/Cpp2CASTConsumer.cc
     Line 320 cpp2c::DefinitionInfoCollector(Ctx);  to  cpp2c::DefnInfoCollector(Ctx);
     Line 324 cpp2c::DefinitionInfoCollector>(DC));  to  cpp2c::DefnInfoCollector>(DC));

Changes were tested for errors by running artifact build commands: docker build -t maki:1.0 ., docker run --name maki-container -it maki:1.0, bash build_clang_plugin.sh, bash build/bin/cpp2c tests/addressed_arguments.c, and bash replicate_results.sh with no errors related to these changes.

This partially satisfies #1 and works from the list created in #3.